### PR TITLE
use 'data-s2-options' as initS2Loading options

### DIFF
--- a/src/assets/yii2-dynamic-form.js
+++ b/src/assets/yii2-dynamic-form.js
@@ -6,6 +6,7 @@
  * @author Wanderson Bragança <wanderson.wbc@gmail.com>
  * @contributor Vivek Marakana <vivek.marakana@gmail.com>
  * @contributor Riza Saputra <riza.saputra@gmail.com>
+ * @contributor Muhammad Yahya Muhaimin <surat.pribadiku@gmail.com>
  */
 (function ($) {
     var pluginName = 'yiiDynamicForm';
@@ -464,6 +465,7 @@
             $hasSelect2.each(function() {
                 var id = $(this).attr('id');
                 var configSelect2 = eval($(this).attr('data-krajee-select2'));
+                var configS2Options = $(this).attr('data-s2-options');
 
                 if ($(this).data('select2')) {
                     $(this).select2('destroy');
@@ -477,7 +479,7 @@
                     _restoreKrajeeDepdrop($(this));
                 }
 
-                $.when($('#' + id).select2(configSelect2)).done(initS2Loading(id, '.select2-container--krajee'));
+                $.when($('#' + id).select2(configSelect2)).done(initS2Loading(id, configS2Options));
 
                 var kvClose = 'kv_close_' + id.replace(/\-/g, '_');
 


### PR DESCRIPTION
When adding an item containing Select2 widget, some of it's properties like `'size'` won't be rendered. Those properties is actually stored in a variable which is mentioned by `'data-s2-options'` HTML attribute.